### PR TITLE
Fix/handle overflow

### DIFF
--- a/inc/ht_sched.hpp
+++ b/inc/ht_sched.hpp
@@ -20,14 +20,14 @@ namespace HT_SCHED
             return instance;
         }
 
-        void setTimingFunction(std::function<unsigned long()>);
+        void setTimingFunction(std::function<uint32_t()>);
         bool schedule(HT_TASK::Task& task);
         void run();
 
         // init function for SchedMon task
-        bool initSchedMon(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);
+        bool initSchedMon(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo);
         // loop for SchedMon task
-        bool schedMon(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);
+        bool schedMon(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo);
         const float& getPeriodicUtilization();
         const float& getIdleUtilization();
         const float& getSchedulerUtilization();
@@ -38,7 +38,7 @@ namespace HT_SCHED
 
         HT_TASK::Task*                  _taskQueue[HT_SCHED_MAX_TASKS]; // ordered list of task object pointers
         int                             _numTasks;
-        std::function<unsigned long()>  _microsFunction;
+        std::function<uint32_t()>       _microsFunction;
         uint32_t                        _timeOfNextExec;        // time at which the next scheduled function must trigger
         uint32_t                        _intervalExecTimer;     // accumulation of time spent executing scheduled tasks
         uint32_t                        _idleExecTimer;         // accumulation of time spent executing idle tasks

--- a/inc/ht_sched.hpp
+++ b/inc/ht_sched.hpp
@@ -39,10 +39,10 @@ namespace HT_SCHED
         HT_TASK::Task*                  _taskQueue[HT_SCHED_MAX_TASKS]; // ordered list of task object pointers
         int                             _numTasks;
         std::function<unsigned long()>  _microsFunction;
-        unsigned long                   _timeOfNextExec;        // time at which the next scheduled function must trigger
-        unsigned long                   _intervalExecTimer;     // accumulation of time spent executing scheduled tasks
-        unsigned long                   _idleExecTimer;         // accumulation of time spent executing idle tasks
-        unsigned long                   _schedulerExecTimer;    // accumulation of time spent in the scheduler
+        uint32_t                        _timeOfNextExec;        // time at which the next scheduled function must trigger
+        uint32_t                        _intervalExecTimer;     // accumulation of time spent executing scheduled tasks
+        uint32_t                        _idleExecTimer;         // accumulation of time spent executing idle tasks
+        uint32_t                        _schedulerExecTimer;    // accumulation of time spent in the scheduler
 
         // variables for SchedMon
         float periodicUtilization;  // CPU utilization of periodic tasks

--- a/inc/ht_task.hpp
+++ b/inc/ht_task.hpp
@@ -2,6 +2,7 @@
 #define __HT_TASK__
 
 #include <functional>
+#include <stdint.h>
 
 namespace HT_TASK
 {    
@@ -18,11 +19,11 @@ namespace HT_TASK
         public:
 
         TaskState       state;
-        unsigned long   executionIntervalMicros;
-        unsigned long   lastExecutionMicros;
-        unsigned long   nextExecutionMicros;
-        unsigned long   filteredExecutionDurationMicros;
-        unsigned long   executions;
+        uint32_t        executionIntervalMicros;
+        uint32_t        lastExecutionMicros;
+        uint32_t        nextExecutionMicros;
+        uint32_t        filteredExecutionDurationMicros;
+        uint32_t        executions;
         unsigned int    id;
         // use priority to enforce ordering when multiple tasks execute on the same scheduling cycle
         unsigned int    priority;   // 0 is highest priority.

--- a/inc/ht_task.hpp
+++ b/inc/ht_task.hpp
@@ -42,7 +42,7 @@ namespace HT_TASK
     };
 
     // Use this to declare a task without a setup or loop
-    inline bool DUMMY_FUNCTION(const unsigned long& timeMicros, const TaskInfo& taskInfo)
+    inline bool DUMMY_FUNCTION(const uint32_t& timeMicros, const TaskInfo& taskInfo)
     {
         return true;
     }
@@ -52,15 +52,15 @@ namespace HT_TASK
         public:  
              
         TaskInfo _taskInfo;
-        std::function<bool(const unsigned long&, const TaskInfo&)> _setup;
-        std::function<bool(const unsigned long&, const TaskInfo&)> _loop;
+        std::function<bool(const uint32_t&, const TaskInfo&)> _setup;
+        std::function<bool(const uint32_t&, const TaskInfo&)> _loop;
 
         // Interval task constructor
         Task(
-            std::function<bool(const unsigned long&, const TaskInfo&)> setup,
-            std::function<bool(const unsigned long&, const TaskInfo&)> loop,
+            std::function<bool(const uint32_t&, const TaskInfo&)> setup,
+            std::function<bool(const uint32_t&, const TaskInfo&)> loop,
             int priority,
-            unsigned long executionIntervalMicros
+            uint32_t executionIntervalMicros
         ) :
         _taskInfo(TaskInfo()),
         _setup(setup),
@@ -73,8 +73,8 @@ namespace HT_TASK
 
         // Idle task constructor with priority
         Task(
-            std::function<bool(const unsigned long&, const TaskInfo&)> setup,
-            std::function<bool(const unsigned long&, const TaskInfo&)> loop,
+            std::function<bool(const uint32_t&, const TaskInfo&)> setup,
+            std::function<bool(const uint32_t&, const TaskInfo&)> loop,
             int priority
         ) :
         _taskInfo(TaskInfo()),

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -1,7 +1,5 @@
 #include "ht_sched.hpp"
 #include <algorithm>
-#include <iostream>
-// #include <iostream>
 
 namespace HT_SCHED
 {

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -1,6 +1,6 @@
 #include "ht_sched.hpp"
 #include <algorithm>
-#include <stdio.h>
+#include <iostream>
 // #include <iostream>
 
 namespace HT_SCHED
@@ -68,8 +68,8 @@ namespace HT_SCHED
     void Scheduler::run()
     {
         // get the time
-        unsigned long nowMicros = _microsFunction();
-        unsigned long cycleExecTimer = 0;
+        uint32_t nowMicros = (uint32_t) _microsFunction();
+        uint32_t cycleExecTimer = 0;
         // used to find the timing of the nearest interval function
         _timeOfNextExec = ULONG_MAX;
 
@@ -110,18 +110,13 @@ namespace HT_SCHED
                         )
                         {
                             // run its loop function
-                            unsigned long dt = _microsFunction();
+                            uint32_t dt = (uint32_t) _microsFunction();
                             bool result = task->_loop(nowMicros, task->_taskInfo);
                             dt = _microsFunction() - dt;
                             if (!result)
                                 task->_taskInfo.state = HT_TASK::TaskState::KILLED;
 
                             task->_taskInfo.nextExecutionMicros += task->_taskInfo.executionIntervalMicros;
-                            if (task->_taskInfo.nextExecutionMicros < task->_taskInfo.lastExecutionMicros) {
-                                std::cout << "looped!";
-                            } else {
-                                std::cout << "did not loop";
-                            }
                             task->_taskInfo.lastExecutionMicros = _microsFunction();
                             task->_taskInfo.filteredExecutionDurationMicros = (dt * 0.5) + (task->_taskInfo.filteredExecutionDurationMicros * 0.5);
                             task->_taskInfo.executions++;

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -104,7 +104,7 @@ namespace HT_SCHED
                         // check if it's time to execute
                         if (
                             // for interval functions, see if nextExecutionMicros has passed
-                            ((task->_taskInfo.isIntervalFunction == true) && (nowMicros - task->_taskInfo.nextExecutionMicros < task->_taskInfo.executionIntervalMicros))
+                            ((task->_taskInfo.isIntervalFunction == true) && (task->_taskInfo.nextExecutionMicros - nowMicros >= task->_taskInfo.executionIntervalMicros))
                             // for idle functions, see if time might conflict with interval function
                             || ((task->_taskInfo.isIntervalFunction == false) && (task->_taskInfo.filteredExecutionDurationMicros + _microsFunction() < _timeOfNextExec))
                         )

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -56,7 +56,7 @@ namespace HT_SCHED
             }
 
             task._taskInfo.id = ++_numTasks;
-
+            task._taskInfo.nextExecutionMicros = (uint32_t) _microsFunction();
             return true;
         }
         else

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -12,7 +12,7 @@ namespace HT_SCHED
         
     }
 
-    void Scheduler::setTimingFunction(std::function<unsigned long()> microsFunction)
+    void Scheduler::setTimingFunction(std::function<uint32_t()> microsFunction)
     {
         _microsFunction = microsFunction;
     }
@@ -140,7 +140,7 @@ namespace HT_SCHED
         _schedulerExecTimer += _microsFunction() - nowMicros - cycleExecTimer;
     }
 
-    bool Scheduler::initSchedMon(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo)
+    bool Scheduler::initSchedMon(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo)
     {
         _intervalExecTimer = 0;
         _idleExecTimer = 0;
@@ -149,9 +149,9 @@ namespace HT_SCHED
         return true;
     }
     
-    bool Scheduler::schedMon(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo)
+    bool Scheduler::schedMon(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo)
     {
-        unsigned long totalTime = _intervalExecTimer + _idleExecTimer + _schedulerExecTimer;
+        uint32_t totalTime = _intervalExecTimer + _idleExecTimer + _schedulerExecTimer;
         periodicUtilization     = (float) _intervalExecTimer    / totalTime;
         idleUtilization         = (float) _idleExecTimer        / totalTime;
         schedulerUtilization    = (float)_schedulerExecTimer    / totalTime;

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -103,7 +103,7 @@ namespace HT_SCHED
                         // check if it's time to execute
                         if (
                             // for interval functions, see if nextExecutionMicros has passed
-                            ((task->_taskInfo.isIntervalFunction == true) && (nowMicros >= task->_taskInfo.nextExecutionMicros))
+                            ((task->_taskInfo.isIntervalFunction == true) && (nowMicros - task->_taskInfo.nextExecutionMicros < task->_taskInfo.executionIntervalMicros))
                             // for idle functions, see if time might conflict with interval function
                             || ((task->_taskInfo.isIntervalFunction == false) && (task->_taskInfo.filteredExecutionDurationMicros + _microsFunction() < _timeOfNextExec))
                         )

--- a/src/ht_sched.cpp
+++ b/src/ht_sched.cpp
@@ -1,5 +1,6 @@
 #include "ht_sched.hpp"
 #include <algorithm>
+#include <stdio.h>
 // #include <iostream>
 
 namespace HT_SCHED
@@ -116,6 +117,11 @@ namespace HT_SCHED
                                 task->_taskInfo.state = HT_TASK::TaskState::KILLED;
 
                             task->_taskInfo.nextExecutionMicros += task->_taskInfo.executionIntervalMicros;
+                            if (task->_taskInfo.nextExecutionMicros < task->_taskInfo.lastExecutionMicros) {
+                                std::cout << "looped!";
+                            } else {
+                                std::cout << "did not loop";
+                            }
                             task->_taskInfo.lastExecutionMicros = _microsFunction();
                             task->_taskInfo.filteredExecutionDurationMicros = (dt * 0.5) + (task->_taskInfo.filteredExecutionDurationMicros * 0.5);
                             task->_taskInfo.executions++;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8,26 +8,26 @@
 
 auto start_time = std::chrono::high_resolution_clock::now();
 
-unsigned long stdMicros()
+uint32_t stdMicros()
 {
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(now - start_time).count();
-    return static_cast<unsigned long>(elapsed);
+    return static_cast<uint32_t>(elapsed);
 }
 
-bool task1F(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo)
+bool task1F(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo)
 {
     std::cout << "task1 exec " << taskInfo.executions << "\n";
     return true;
 }
 
-bool task2F(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo)
+bool task2F(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo)
 {
     std::cout << "task2 exec " << taskInfo.executions << "\n";
     return true;
 }
 
-bool task3F(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo)
+bool task3F(const uint32_t& sysMicros, const HT_TASK::TaskInfo& taskInfo)
 {
     // std::cout << "task3 filtered duration " << taskInfo.filteredExecutionDurationMicros << "\n";
     // std::cout << "task3 last execution " << taskInfo.lastExecutionMicros << "\n";


### PR DESCRIPTION
Changed to use the subtraction trick Ben sent, and replaced all "unsigned long" with "uint32_t" due to inconsistent integer lengths. On Arduino, even though micros() returns unsigned long, it returns a 32-bit integer. However, when running scheduler tests on my local machine, unsigned long was 64 bits, and wasn't rolling over the way I expected it to. By explicitly declaring everything as a uint32_t, we should be able to bypass this problem.


citation: https://www.embeddedrelated.com/showarticle/1636.php